### PR TITLE
fix: Ensure correct error location

### DIFF
--- a/test-workspaces/simple/hello.test.js
+++ b/test-workspaces/simple/hello.test.js
@@ -8,4 +8,7 @@ describe('math', () => {
   it('subtraction', async () => {
     strictEqual(1 - 1, 0);
   });
+  it('failing', async () => {
+    strictEqual(1 * 1, 0);
+  });
 });

--- a/test-workspaces/typescript/hello.test.ts
+++ b/test-workspaces/typescript/hello.test.ts
@@ -20,4 +20,8 @@ describe('math', () => {
   it('subtraction', async () => {
     strictEqual((1 - 1) as number, 0 as any as number);
   });
+
+  it('failing', async () => {
+    strictEqual((1 * 1) as number, 0 as any as number);
+  });
 });


### PR DESCRIPTION
There was a problem that the error location on failing test could not be decoded. 