### PR TITLE
build: Add Open VSX Publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,10 +27,19 @@ jobs:
       - name: Install dependencies
         run: npm install
 
-      - name: Build and Publish
-        run: npm run publish:prerelease
+      - name: Build and Package
+        run: npm run package:release
+
+      - name: Publish (Microsoft Extension Gallery)
+        run: npm run publish:vsce:prerelease
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
+
+      - name: Build and Publish (Open VSX Registry)
+        run: npm run publish:ovsx:prerelease
+        env:
+          OVSX_PAT: ${{ secrets.OVSX_PAT }}
+
 
   release:
     name: Release (Full)
@@ -50,7 +59,15 @@ jobs:
       - name: Install dependencies
         run: npm install
 
-      - name: Build and Publish
-        run: npm run publish:release
+      - name: Build and Package
+        run: npm run package:release
+
+      - name: Build and Publish (Microsoft Extension Gallery)
+        run: npm run publish:vsce:release
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
+
+      - name: Build and Publish (Open VSX Registry)
+        run: npm run publish:ovsx:release
+        env:
+          OVSX_PAT: ${{ secrets.OVSX_PAT }}

--- a/package.json
+++ b/package.json
@@ -107,8 +107,10 @@
   "homepage": "https://github.com/CoderLine/mocha-vscode#readme",
   "main": "./out/extension.js",
   "scripts": {
-    "publish:release": "npm run compile && tsx ./scripts/prerelease.mts && npx @vscode/vsce publish",
-    "publish:prerelease": "npm run compile && tsx ./scripts/prerelease.mts --pre-release && npx @vscode/vsce publish --pre-release",
+    "publish:vsce:release": "npx @vscode/vsce publish",
+    "publish:vsce:prerelease": "npx @vscode/vsce publish --pre-release",
+    "publish:ovsx:release": "npx ovsx publish",
+    "publish:ovsx:prerelease": "npx ovsx publish --pre-release",
     "package:release": "npm run compile && tsx ./scripts/prerelease.mts && npx @vscode/vsce package",
     "package:prerelease": "npm run compile && tsx ./scripts/prerelease.mts --pre-release && npx @vscode/vsce package --pre-release",
     "vscode:prepublish": "npm run compile",


### PR DESCRIPTION
Adds publishing to the Open VSX Registry. 

Still waiting for the some approval things from the Eclipse Foundation to get this really working.