### PR TITLE
fix: Avoid ESBuild destroying Proxy in __toESM

### DIFF
--- a/src/test/integration/typescript.test.ts
+++ b/src/test/integration/typescript.test.ts
@@ -84,7 +84,7 @@ describe('typescript', () => {
     expect(failed.message?.location).to.not.be.undefined;
     expect(failed.message?.location?.uri.toString()).to.include('hello.test.ts');
     expect(path.isAbsolute(failed.message!.location!.uri.fsPath)).to.be.true;
-    expect(failed.message?.location?.range.start.line).to.equal(25);
+    expect(failed.message?.location?.range.start.line).to.equal(29);
     expect(failed.message?.location?.range.start.character).to.equal(5);
   });
 });

--- a/test-workspaces/typescript/hello.test.ts
+++ b/test-workspaces/typescript/hello.test.ts
@@ -1,4 +1,8 @@
 import { strictEqual } from 'node:assert';
+import path, { join } from 'node:path';
+
+path.join('', '');
+join('', '');
 
 // just some typescript code which would be valid directly in Node
 


### PR DESCRIPTION
Fixes #153

When transpiling typescript (or ESM) toa ESBuild, it translates imports in a way like this: 

TypeScript: 
```ts
import path, { join } from 'node:path';
```

JS:
```js
"use strict";
var __create = Object.create;
var __defProp = Object.defineProperty;
var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
var __getOwnPropNames = Object.getOwnPropertyNames;
var __getProtoOf = Object.getPrototypeOf;
var __hasOwnProp = Object.prototype.hasOwnProperty;
var __name = (target, value) => __defProp(target, "name", { value, configurable: true });
var __copyProps = (to, from, except, desc) => {
  if (from && typeof from === "object" || typeof from === "function") {
    for (let key of __getOwnPropNames(from))
      if (!__hasOwnProp.call(to, key) && key !== except)
        __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
  }
  return to;
};
var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__getProtoOf(mod)) : {}, __copyProps(
  // If the importer is in node compatibility mode or this is not an ESM
  // file that has been converted to a CommonJS file using a Babel-
  // compatible transform (i.e. "__esModule" has not been set), then set
  // "default" to the CommonJS "module.exports" for node compatibility.
  isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", { value: mod, enumerable: true }) : target,
  mod
));
var import_node_path = __toESM(require("node:path"));
import_node_path.default.join("", "");
(0, import_node_path.join)("", "");
```

As we can see, it created a complete new object using Object.create copying all individual properties over. This way it translates ESM modules to CJS during runtime respecting the `__esModule` flags. This completely destroys our `Proxy` object representing our fake imported module. 

With this fix we ensure `Object.create` also will create again a `Proxy` object restoring our runtime dynamic module.