### PR TITLE
feat: nodePath & mochaPath

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ This extension automatically discovers and works with the `.mocharc.js/cjs/yaml/
 
 - `mocha-vscode.env`: Additional environment variables set when executing tests. This is useful for setting things like `NODE_ENV`.
 
+- `mocha-vscode.mochaPath`: Specifies the path to the Mocha executable. If not set, the extension will attempt to resolve the Mocha executable from the local `node_modules` directory.
+- `mocha-vscode.nodePath`: Specifies the path to the Node.js executable. If not set, the extension will use the default Node.js executable.
+
 ## Features
 
 ### Show, Running and Debugging Tests

--- a/package.json
+++ b/package.json
@@ -105,6 +105,16 @@
             "type": "object",
             "additionalProperties": true,
             "markdownDescription": "Additional environment variables set when executing tests. This is useful for setting things like `NODE_ENV`."
+          },
+          "mocha-vscode.nodePath": {
+            "type": "string",
+            "default": "",
+            "description": "Path to the Node.js executable."
+          },
+          "mocha-vscode.mochaPath": {
+            "type": "string",
+            "default": "",
+            "description": "Path to the Mocha executable."
           }
         }
       }

--- a/src/configurationFile.ts
+++ b/src/configurationFile.ts
@@ -93,7 +93,8 @@ export class ConfigurationFile implements vscode.Disposable {
   }
 
   async getMochaSpawnArgs(customArgs: readonly string[]): Promise<string[]> {
-    this._pathToMocha ??= await this._resolveLocalMochaBinPath();
+    const mochaPath = vscode.workspace.getConfiguration('mocha-vscode').get<string>('mochaPath');
+    this._pathToMocha = mochaPath || (await this._resolveLocalMochaBinPath());
 
     return [
       await getPathToNode(this.logChannel),

--- a/src/node.ts
+++ b/src/node.ts
@@ -25,6 +25,13 @@ export async function getPathTo(logChannel: vscode.LogOutputChannel, bin: string
 let pathToNode: string | null = null;
 
 export async function getPathToNode(logChannel: vscode.LogOutputChannel) {
+  // Check if the nodePath setting is defined
+  const nodePath = vscode.workspace.getConfiguration('mocha-vscode').get<string>('nodePath');
+  if (nodePath) {
+    logChannel.debug(`Using nodePath from settings: '${nodePath}'`);
+    return nodePath;
+  }
+
   // We cannot use process.execPath as this points to code.exe which is an electron application
   // also with ELECTRON_RUN_AS_NODE this can lead to errors (e.g. with the --import option)
   // we prefer to use the system level node


### PR DESCRIPTION
closes #209 

This pull request adds settings for both `mochaPath` and `nodePath`. I was hoping this would help me to get [`electron-mocha`](https://github.com/jprichardson/electron-mocha/tree/master) working with this extension, but simply swapping out `electron-mocha` for `mocha` doesn't seem to do it.

Nonetheless, here's a PR of my changes.

And here's the robot has to say about it:

This pull request introduces new configuration options for specifying the paths to the Mocha and Node.js executables, and updates the code to utilize these configurations. The changes enhance the flexibility of the extension by allowing users to specify custom paths for these executables.

New configuration options:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R32-R34): Added descriptions for `mocha-vscode.mochaPath` and `mocha-vscode.nodePath` settings, which specify the paths to the Mocha and Node.js executables, respectively.

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R108-R117): Added `mocha-vscode.mochaPath` and `mocha-vscode.nodePath` settings to the configuration schema.

Code updates to use new configurations:

* [`src/configurationFile.ts`](diffhunk://#diff-d620691fe6dd4efe8ff0a743ce425793bde26cb7741c35133b06e28acbad5297L96-R97): Updated `getMochaSpawnArgs` method to use the `mochaPath` setting if defined, falling back to resolving the local Mocha binary path if not.

* [`src/node.ts`](diffhunk://#diff-22b97ef1141174ca5a814b313942e79b626a55c7cd1ebe7b97d0756298b03641R28-R34): Updated `getPathToNode` function to use the `nodePath` setting if defined, logging the path being used.