### PR TITLE
fix: Wrong source locations for source maps

### DIFF
--- a/src/runner.ts
+++ b/src/runner.ts
@@ -707,9 +707,12 @@ async function deriveSourceLocation(
 
   const maintainer = store.maintain(fileUri);
   const mapping = await (maintainer.value || maintainer.refresh());
+  // in parsed stack traces line and column numbers are 1-based, in the VS Code APIs lines are 0-based
+  const zeroBasedLine = Number(line) - 1;
+  const zeroBasedCol = Number(col) - 1;
   const value =
-    mapping?.originalPositionFor(Number(line), Number(col)) ||
-    new vscode.Location(fileUri, new vscode.Position(Number(line), Number(col)));
+    mapping?.originalPositionFor(zeroBasedLine, zeroBasedCol) ||
+    new vscode.Location(fileUri, new vscode.Position(zeroBasedLine, zeroBasedCol));
 
   // timeout the maintainer async so that it stays alive for any other immediate teset usage in the file:
   setTimeout(() => maintainer.dispose(), 5000);

--- a/src/source-map.ts
+++ b/src/source-map.ts
@@ -30,6 +30,7 @@ export const identityMapping = (file: vscode.Uri): IMappingAccessor => ({
 });
 
 const smMappingAccessor = (file: vscode.Uri, sm: TraceMap): IMappingAccessor => ({
+  // @jridgewell/trace-mapping: Lines start at line 1, columns at column 0.
   originalPositionFor(line, column) {
     const {
       source,

--- a/src/test/integration/simple.test.ts
+++ b/src/test/integration/simple.test.ts
@@ -235,8 +235,8 @@ describe('simple', () => {
     expect(failed.message?.location).to.not.be.undefined;
     expect(failed.message?.location?.uri.toString()).to.include('hello.test.js');
     expect(path.isAbsolute(failed.message!.location!.uri.fsPath)).to.be.true;
-    expect(failed.message?.location?.range.start.line).to.equal(12);
-    expect(failed.message?.location?.range.start.character).to.equal(5);
+    expect(failed.message?.location?.range.start.line).to.equal(11);
+    expect(failed.message?.location?.range.start.character).to.equal(4);
   });
 
   it('handles file and directory excludes', async () => {
@@ -318,10 +318,10 @@ describe('simple', () => {
     });
 
     const failed = run.states.find((s) => s.state === 'failed');
-    expect(failed!.message!.location!.range.start.line).to.equal(4);
-    expect(failed!.message!.location!.range.start.character).to.equal(11);
-    expect(failed!.message!.location!.range.end.line).to.equal(4);
-    expect(failed!.message!.location!.range.end.character).to.equal(11);
+    expect(failed!.message!.location!.range.start.line).to.equal(3);
+    expect(failed!.message!.location!.range.start.character).to.equal(10);
+    expect(failed!.message!.location!.range.end.line).to.equal(3);
+    expect(failed!.message!.location!.range.end.character).to.equal(10);
     expect(failed!.message!.location!.uri.fsPath).to.equal(item.uri!.fsPath);
   });
 });

--- a/src/test/integration/typescript.test.ts
+++ b/src/test/integration/typescript.test.ts
@@ -84,7 +84,7 @@ describe('typescript', () => {
     expect(failed.message?.location).to.not.be.undefined;
     expect(failed.message?.location?.uri.toString()).to.include('hello.test.ts');
     expect(path.isAbsolute(failed.message!.location!.uri.fsPath)).to.be.true;
-    expect(failed.message?.location?.range.start.line).to.equal(29);
-    expect(failed.message?.location?.range.start.character).to.equal(5);
+    expect(failed.message?.location?.range.start.line).to.equal(28);
+    expect(failed.message?.location?.range.start.character).to.equal(4);
   });
 });


### PR DESCRIPTION
Fixes #214

Seems after various changes in the source mapping area the whole 0-based and 1-based line/col handling got messed up.