### PR TITLE
fix: file path handling and CLI output for copy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mocha-vscode",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mocha-vscode",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "hasInstallScript": true,
       "dependencies": {
         "esbuild": "^0.25.2"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Mocha for VS Code",
   "description": "Run and debug Mocha tests right within VS Code.",
   "publisher": "coderline",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "icon": "icon.png",
   "engines": {
     "vscode": "^1.83.0"


### PR DESCRIPTION
Fixes a problem that file paths were converted to lowercase on Windows. This leads to wrong file casing (e.g. jest-snapshot). No problem on Windows. But on Linux snapshots written on Windows are not matched correctly. 

+ Added better command output for copying purposes (e.g. to easily add `--updateSnapshot`)